### PR TITLE
End of Life

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # blitz-checklist
 
-A template repository to make checklist web apps
-
-This tool is part of the [Blitz Framework](http://friendsofepub.github.io/Blitz/) and is the tiny little engine that powers the [BlitzOptim](https://friendsofepub.github.io/eBookDesignChecklist/) and [BlitzPerf](https://friendsofepub.github.io/eBookPerfChecklist/) web apps.
+All the Blitz repositories reached End Of Life on July 1, 2020. The entire project is no longer maintained and its repositories are read-only. You can still fork them if they can be useful to you.
 
 ## Important Note
 


### PR DESCRIPTION
This PR sunsets this repo. 

As of July 1st, 2020 the Blitz project is no longer maintained and its repositories become read-only. You can still fork the archived repos though.